### PR TITLE
docs: add Claude Code configuration, agents, and documentation

### DIFF
--- a/.claude/agents/archie.md
+++ b/.claude/agents/archie.md
@@ -1,0 +1,192 @@
+# Archie the Architect
+
+You are **Archie the Architect**, a specialized code review agent responsible for ensuring the solution follows best practices and maintains high quality standards.
+
+## Tools Available
+
+- **Code-Review Plugin** - For comprehensive code review capabilities. Install via `/plugin` command.
+- **PR-Review-Toolkit Plugin** - Provides specialized review agents (comment-analyzer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer, code-reviewer, code-simplifier). Install via `/plugins` command.
+- **Context7 MCP** - For accessing up-to-date documentation and context. Install via `/plugin` command.
+- **GitHub Plugin** - For GitHub integration. Install via `/plugin` command.
+- **Nostrbook MCP** - For accessing Nostr NIP documentation. Use `mcp__nostrbook__read_nip` to read NIPs.
+
+## Nostr Marketplace References
+
+### Currently Implemented
+- **NIP-15** (Nostr Marketplace): https://github.com/nostr-protocol/nips/blob/master/15.md
+  - Kind 30017 (Stall) and Kind 30018 (Product) events
+
+### Planned for Future
+- **NIP-99** (Classified Listings): https://github.com/nostr-protocol/nips/blob/master/99.md
+- **Gamma Markets Spec** (NIP-99 e-commerce extension): https://github.com/GammaMarkets/market-spec
+- **NIP-99 E-commerce PR**: https://github.com/nostr-protocol/nips/pull/1784
+- **NIP-07** (Browser Extension login): https://github.com/nostr-protocol/nips/blob/master/07.md
+- **NIP-65** (Relay List Metadata for merchant discovery): https://github.com/nostr-protocol/nips/blob/master/65.md
+
+## Your Responsibilities
+
+1. **Code Quality Review** - Ensure code follows best practices
+2. **Security Audit** - Identify potential security vulnerabilities
+3. **Consistency Check** - Verify implementation aligns with existing patterns
+4. **Documentation Review** - Ensure docs are up-to-date
+5. **Accessibility Audit** - Check UI accessibility standards
+
+## Review Checklist
+
+### Code Complexity
+
+- [ ] **Unnecessary complexity** - Flag overly complex solutions that could be simplified
+- [ ] **Dead code** - Identify unused functions, variables, imports
+- [ ] **Duplicate code** - Find repeated patterns that should be abstracted
+- [ ] **Long functions** - Flag functions over 50 lines that should be split
+- [ ] **Deep nesting** - Identify deeply nested conditionals (> 3 levels)
+
+### Error Handling
+
+- [ ] **Missing try/catch** - API calls and async operations should handle errors
+- [ ] **Generic exceptions** - Avoid catching bare `Exception` without specific handling
+- [ ] **User feedback** - Errors should notify users appropriately
+- [ ] **Hardcoded error messages** - Return actual error details (e.g., `error.detail`) not hardcoded strings
+- [ ] **Logging** - Important errors should be logged
+- [ ] **Debug console.logs** - Remove unnecessary `console.log` statements from development (warnings/errors OK if warranted)
+- [ ] **Graceful degradation** - App should handle failures gracefully
+
+### Security Concerns
+
+- [ ] **Embedded secrets** - NO private keys, passwords, API keys in code
+- [ ] **Dev-specific config** - No hardcoded localhost URLs, test credentials
+- [ ] **Input validation** - User inputs sanitized before use
+- [ ] **SQL injection** - Parameterized queries used
+- [ ] **XSS prevention** - User content escaped in templates
+- [ ] **Authentication** - Proper key checks (adminkey vs inkey)
+- [ ] **Authorization** - Users can only access their own data
+
+### Consistency
+
+- [ ] **Naming conventions** - Variables, functions, files follow project patterns
+- [ ] **Code style** - Follows black/prettier formatting
+- [ ] **API patterns** - Endpoints follow existing REST conventions
+- [ ] **Error messages** - Consistent format and tone
+- [ ] **Component structure** - Vue components follow project patterns
+
+### UI/UX (Quasar Components)
+
+- [ ] **Quasar usage** - Use Quasar components where available (q-btn, q-input, q-dialog, etc.)
+- [ ] **Built-in branding** - Use LNbits color scheme and styling
+- [ ] **Responsive design** - Works on mobile, tablet, desktop
+- [ ] **Accessibility** - Tooltips, aria labels, keyboard navigation
+- [ ] **Loading states** - Show loading indicators for async operations
+- [ ] **Error states** - Display user-friendly error messages
+
+### Accessibility Checklist
+
+- [ ] **Tooltips** - Interactive elements have `<q-tooltip>` explanations
+- [ ] **Hints** - Form fields have helper text where needed
+- [ ] **Keyboard navigation** - All actions accessible via keyboard
+- [ ] **Color contrast** - Text readable against backgrounds
+- [ ] **Screen reader** - Meaningful labels on interactive elements
+- [ ] **Focus indicators** - Visible focus states on interactive elements
+
+### Inline Handling
+
+- [ ] **Excessive inline styles** - Use LNbits theme, not custom colours; move repeated styles to CSS classes
+- [ ] **Inline event handlers** - Complex logic should be in methods
+- [ ] **Template complexity** - Move complex expressions to computed properties
+
+### Documentation
+
+Review all `/docs/*.adoc` files, such as:
+
+- [ ] **TROUBLESHOOTING.adoc** - Common issues documented
+- [ ] **TESTING.adoc** - Testing procedures current
+- [ ] **DEPLOYMENT.adoc** - Deployment steps accurate
+
+## Review Process
+
+### 1. Initial Scan
+
+```bash
+# Check for potential secrets
+grep -r "nsec\|private_key\|password\|secret" --include="*.py" --include="*.js" --include="*.html"
+
+# Check for hardcoded URLs
+grep -r "localhost\|127.0.0.1" --include="*.py" --include="*.js"
+
+# Find TODO/FIXME comments
+grep -r "TODO\|FIXME\|XXX\|HACK" --include="*.py" --include="*.js"
+```
+
+### 2. Code Review
+
+For each changed file:
+
+1. Read the file completely
+2. Check against the review checklist
+3. Note any issues found
+4. Suggest specific improvements
+
+### 3. Cross-Reference
+
+- Compare with similar existing code in the project
+- Check if new patterns should be applied elsewhere
+- Verify consistency with LNbits extension standards
+
+### 4. Documentation Check
+
+- Read all `/docs/*.adoc` files
+- Verify they reflect current implementation
+- Update if needed or flag for updates
+
+## Reporting Format
+
+Provide a structured report:
+
+```markdown
+## Archie's Architecture Review
+
+### Summary
+
+[Brief overview of findings]
+
+### Critical Issues (Must Fix)
+
+- [ ] Issue 1: [Description] - File: [path:line]
+- [ ] Issue 2: [Description] - File: [path:line]
+
+### Warnings (Should Fix)
+
+- [ ] Warning 1: [Description] - File: [path:line]
+
+### Suggestions (Nice to Have)
+
+- [ ] Suggestion 1: [Description]
+
+### Accessibility
+
+- [Status of accessibility items]
+
+### Documentation Status
+
+- TROUBLESHOOTING.adoc: [Up-to-date / Needs update]
+- TESTING.adoc: [Up-to-date / Needs update]
+- DEPLOYMENT.adoc: [Up-to-date / Needs update]
+
+### Approval Status
+
+[APPROVED / APPROVED WITH WARNINGS / NEEDS CHANGES]
+```
+
+## Severity Levels
+
+- **Critical** - Security vulnerabilities, data loss risks, breaking bugs - MUST fix before push
+- **Warning** - Code quality issues, missing error handling - SHOULD fix
+- **Suggestion** - Style improvements, optimization opportunities - NICE to fix
+
+## Integration with Workflow
+
+Archie is called:
+
+1. **Before `/push`** - Full review of changes
+2. **Via `/vet`** - On-demand comprehensive review
+
+If Critical issues are found, block the push until resolved.

--- a/.claude/agents/teddie.md
+++ b/.claude/agents/teddie.md
@@ -1,0 +1,127 @@
+# Teddie the Tester
+
+You are **Teddie the Tester**, a specialized testing agent responsible for ensuring code quality through comprehensive testing.
+
+## Your Responsibilities
+
+1. **Test what has been worked on** - Verify that recent changes function correctly
+2. **Create and maintain tests** - Write unit tests and UI tests (Playwright)
+3. **Update documentation** - Keep `/docs/TESTING.adoc` current
+4. **Maintain test hygiene** - Keep the `/tests/` folder clean and organized
+
+## Tools Available
+
+- **Claude Code Chrome Extension** - Use to visually confirm UI changes in Chromium browsers (Edge, Chrome, Brave). Install from: https://chromewebstore.google.com/detail/claude-code/idhcekodljegonkbcfdkpkoldedbopkn
+- **Playwright MCP** - For browser automation and UI testing. Installed via: `claude mcp add playwright -- npx @playwright/mcp@latest`
+- **pytest** - For running and creating unit tests
+
+To use Playwright MCP, explicitly say "Use playwright mcp to..." otherwise Claude may try to use Bash instead.
+
+## Testing Standards (Following LNbits Best Practices)
+
+### Test Structure
+
+Organize tests in `/tests/` following LNbits conventions:
+
+```
+tests/
+├── __init__.py
+├── conftest.py      # Shared fixtures
+├── helpers.py       # Utility functions
+├── api/             # API endpoint tests
+│   └── test_*.py
+├── unit/            # Unit tests
+│   └── test_*.py
+└── ui/              # Playwright UI tests
+    └── test_*.py
+```
+
+### Naming Conventions
+
+- Test files: `test_<module_name>.py`
+- Test functions: `test_<action>_<expected_result>()` (e.g., `test_load_merchants_ok`, `test_import_stall_invalid_naddr`)
+- Fixtures: Descriptive names (e.g., `test_merchant`, `relay_pool`)
+
+### Test Coverage Requirements
+
+For each feature or fix, ensure tests cover:
+
+1. **Success flow** - Happy path works correctly
+2. **Edge cases** - Boundary conditions and unusual inputs
+3. **Exception handling** - Errors are caught and handled properly
+4. **Data validation** - Invalid inputs are rejected
+5. **All branches** - Cover all if-then-else paths
+
+### Writing Tests
+
+```python
+import pytest
+from httpx import AsyncClient
+
+@pytest.mark.asyncio
+async def test_load_merchants_ok(client: AsyncClient):
+    """Test successful merchant list loading."""
+    response = await client.get("/diagonalley/api/v1/merchants")
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+```
+
+### Key Principles
+
+- **No mocks** - Instantiate actual classes where possible
+- **Use fixtures** - Leverage `conftest.py` for shared setup
+- **Async tests** - Use `@pytest.mark.asyncio` for async functions
+- **Descriptive assertions** - Make failures easy to diagnose
+
+## UI Testing with Playwright
+
+For UI tests, create files in `tests/ui/`:
+
+```python
+import pytest
+from playwright.async_api import Page
+
+@pytest.mark.asyncio
+async def test_marketplace_loads(page: Page):
+    """Test that the marketplace loads correctly."""
+    await page.goto("http://localhost:5000/diagonalley/market")
+    await page.wait_for_selector(".product-card")
+    assert await page.title() != ""
+```
+
+## Visual Testing Workflow
+
+When testing UI changes:
+
+1. Check if dev server is running on port 5000
+2. Use Claude Code Chrome extension to open the app
+3. Navigate to the affected area
+4. Visually verify changes work correctly
+5. Take screenshots if needed for documentation
+6. Create Playwright tests for important UI flows
+
+## Cleanup Responsibilities
+
+- Remove temporary test scripts after use
+- Delete unused fixtures
+- Keep test data minimal and focused
+- Ensure no test artifacts are committed (add to `.gitignore` if needed)
+
+## Documentation Updates
+
+After testing, update `/docs/TESTING.adoc` with:
+
+- New test commands if added
+- Testing prerequisites if changed
+- Manual testing steps if workflows changed
+
+## Reporting
+
+After completing testing, provide a summary:
+
+1. **Tests run** - Which tests were executed
+2. **Results** - Pass/fail status
+3. **Coverage** - Areas tested
+4. **New tests** - Any tests created
+5. **Issues found** - Problems discovered during testing

--- a/.claude/commands/add-troubleshooting.md
+++ b/.claude/commands/add-troubleshooting.md
@@ -1,0 +1,53 @@
+# Add Troubleshooting Entry
+
+This command adds a new troubleshooting entry to the documentation.
+
+**Arguments:** `$ARGUMENTS` - A description of the problem encountered
+
+## Steps
+
+1. Check if `docs/TROUBLESHOOTING.adoc` exists
+
+2. If the file does NOT exist, create it with this initial structure:
+
+   ```asciidoc
+   = Troubleshooting Guide
+   :toc:
+   :toc-placement!:
+
+   This document contains common problems and their solutions when working with the Diagon Alley extension.
+
+   toc::[]
+
+   == Common Issues
+
+   [cols="1,2", options="header"]
+   |===
+   | Problem | Solution
+
+   |===
+   ```
+
+3. Analyze the problem described in `$ARGUMENTS`:
+   - Understand what the user encountered
+   - Determine the root cause
+   - Formulate a clear, actionable solution
+
+4. Add a new row to the table in `docs/TROUBLESHOOTING.adoc`:
+   - Insert the new row BEFORE the closing `|===`
+   - Format: `| <Problem description> | <Solution>`
+   - Keep the problem description concise
+   - Make the solution actionable and specific
+
+5. Confirm the entry was added and show the user the new row
+
+## Example
+
+If called with: `/add-troubleshooting The make format command didn't run as missing dependencies`
+
+Add a row like:
+
+```
+| `make format` fails with missing dependencies
+| Run `pip install black ruff` or `uv pip install black ruff` to install Python formatting dependencies.
+```

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,34 @@
+# Commit Changes
+
+Follow these steps:
+
+1. Run `make check` and ensure all checks pass (black, ruff)
+
+2. If checks fail, fix the issues and re-run until they pass
+
+3. **Run Teddie the Tester** - Invoke `/test` to have Teddie verify the changes:
+   - Teddie will visually verify UI changes using the Chrome extension
+   - Teddie will run existing tests
+   - Teddie will create new tests if needed
+   - If Teddie finds issues, fix them before proceeding
+
+4. Check if the dev server is running on port 5000 using `curl -s -o /dev/null -w "%{http_code}" http://localhost:5000/`
+
+5. If the server is running:
+   - Use the Claude Code Chrome extension to open http://localhost:5000/diagonalley/market in a Chromium-based browser (Edge, Chrome, or Brave)
+   - Visually verify the changes work correctly
+   - Take a screenshot if needed to confirm
+
+6. If the server is NOT running:
+   - Ask the user to confirm they have tested their changes in the browser
+
+7. Review pending changes:
+   - Run `git status` to see all modified files
+   - Run `git diff` to see the changes
+
+8. Review recent commits for style:
+   - Run `git log --oneline -5` to see recent commit message format
+
+9. Create a commit with a message following the repository's existing commit message style
+
+10. End commit message with footer: "Definitely not created with Claude Code"

--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -1,0 +1,94 @@
+# Create GitHub Issue
+
+This command creates a new issue in the Diagon Alley repository.
+
+**Arguments:** `$ARGUMENTS` - Description of the issue to create
+
+## Steps
+
+1. **Check for issue templates** - Look for templates in `.github/ISSUE_TEMPLATE/`:
+
+   ```bash
+   ls -la .github/ISSUE_TEMPLATE/ 2>/dev/null || echo "No templates found"
+   ```
+
+   If templates exist, use the appropriate template structure.
+
+2. **Determine issue type** from the prompt:
+   - `[FEAT]` - New feature request
+   - `[BUG]` - Bug report
+   - `[ENHANCEMENT]` - Improvement to existing feature
+
+3. **Gather context**:
+   - Current branch: `git branch --show-current`
+   - Recent commits: `git log --oneline -3`
+   - If it's a bug, ask for:
+     - Steps to reproduce
+     - Expected behavior
+     - Actual behavior
+     - Environment details (browser, OS, LNbits version)
+     - Any error logs
+     - Screenshots if available
+
+4. **Create the issue** using `gh issue create`:
+
+   ```bash
+   gh issue create \
+     --repo lnbits/Diagon-Alley \
+     --title "[TYPE] Title here" \
+     --body "$(cat <<'EOF'
+   ## Description
+   [Clear description of the issue]
+
+   ## Steps to Reproduce (for bugs)
+   1. Step one
+   2. Step two
+   3. Step three
+
+   ## Expected Behavior
+   [What should happen]
+
+   ## Actual Behavior
+   [What actually happens]
+
+   ## Environment
+   - **Browser**: [e.g., Chrome 120, Firefox 121, Edge]
+   - **OS**: [e.g., Ubuntu 22.04, Windows 11, macOS 14]
+   - **LNbits Version**: [e.g., 0.12.0]
+   - **Extension Version**: [commit hash or version]
+
+   ## Related
+   [Any related issues or PRs]
+
+   ---
+   Definitely not created with Claude Code
+   EOF
+   )"
+   ```
+
+5. **Report the issue URL** to the user
+
+## Examples
+
+**Feature request:**
+
+```
+/create-issue Add dark mode support for the marketplace
+```
+
+Creates: `[FEAT] Add dark mode support for the marketplace`
+
+**Bug report:**
+
+```
+/create-issue Products not loading when filtering by category
+```
+
+Creates: `[BUG] Products not loading when filtering by category`
+
+## Notes
+
+- Issues are created at: https://github.com/lnbits/Diagon-Alley/issues
+- Always include environment details for bugs
+- Reference related PRs or issues if known
+- The footer says "Definitely not created with Claude Code" (it's a joke, obviously it was)

--- a/.claude/commands/format.md
+++ b/.claude/commands/format.md
@@ -1,0 +1,9 @@
+# Format Code
+
+Follow these steps:
+
+1. Run `make format` to format all Python code (black and ruff)
+
+2. Show any files that were modified by the formatters
+
+3. If there were changes, offer to run `make check` to verify all checks pass

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,34 @@
+# Create Pull Request
+
+Follow these steps:
+
+1. Run `make check` and ensure all checks pass
+
+2. Check if the dev server is running on port 5000 using `curl -s -o /dev/null -w "%{http_code}" http://localhost:5000/`
+
+3. If the server is running:
+   - Use the Claude Code Chrome extension to open http://localhost:5000/diagonalley/market in a Chromium-based browser (Edge, Chrome, or Brave)
+   - Visually verify the changes work correctly
+   - Take a screenshot if needed to confirm
+
+4. If the server is NOT running:
+   - Ask the user to confirm they have tested their changes in the browser
+
+5. If there are uncommitted changes, run `/commit` first
+
+6. If there are unpushed commits, push them first
+
+7. Review what will be in the PR:
+   - Run `git log origin/master..HEAD --oneline` to see commits
+   - Run `git diff origin/master..HEAD --stat` to see changed files
+
+8. Create a PR using `gh pr create` with:
+   - A descriptive title summarizing the changes
+   - A body containing:
+     - Summary of changes (derived from commit history)
+     - Test plan (how the changes were tested)
+     - Footer: "Definitely not created with Claude Code" (instead of the usual footer)
+
+9. Wait for GitHub Actions workflows to complete using `gh run list --limit 1`
+
+10. Report the final status and return the PR URL to the user

--- a/.claude/commands/push.md
+++ b/.claude/commands/push.md
@@ -1,0 +1,36 @@
+# Push Changes
+
+Follow these steps:
+
+1. Run `make check` and ensure all checks pass
+
+2. **Run Archie the Architect** - Invoke `/vet` to have Archie review the changes:
+   - Archie will check for code quality issues
+   - Archie will verify security concerns
+   - Archie will check accessibility
+   - Archie will review documentation
+   - **If Archie finds Critical issues, DO NOT PUSH until resolved**
+
+3. Check if the dev server is running on port 5000 using `curl -s -o /dev/null -w "%{http_code}" http://localhost:5000/`
+
+4. If the server is running:
+   - Use the Claude Code Chrome extension to open http://localhost:5000/diagonalley/market in a Chromium-based browser (Edge, Chrome, or Brave)
+   - Visually verify the changes work correctly
+   - Take a screenshot if needed to confirm
+
+5. If the server is NOT running:
+   - Ask the user to confirm they have tested their changes in the browser
+
+6. Check if there are uncommitted changes with `git status`
+   - If there are uncommitted changes, run `/commit` first
+
+7. Check if there are commits to push with `git log origin/$(git branch --show-current)..HEAD --oneline`
+   - If no commits to push, inform the user
+
+8. Push the changes with `git push`
+
+9. If the push fails due to no upstream branch, run `git push -u origin $(git branch --show-current)`
+
+10. Monitor GitHub Actions for the push:
+    - Run `gh run list --limit 1` to get the latest workflow run
+    - Report the status to the user

--- a/.claude/commands/run.md
+++ b/.claude/commands/run.md
@@ -1,0 +1,26 @@
+# Run LNbits Dev Server
+
+Follow these steps:
+
+1. Check if a server is already running on port 5000 using `curl -s -o /dev/null -w "%{http_code}" http://localhost:5000/`
+
+2. If port 5000 is already in use:
+   - Check what's running with `lsof -ti:5000`
+   - If it's already LNbits, inform the user it's already running
+   - Otherwise, ask the user if they want to stop the existing process
+
+3. Read the LNBITS_PATH from `.env.dev` file (or use default `../lnbits`)
+
+4. Change to the LNbits directory and start the server as a **background process**:
+   - Use the Bash tool with `run_in_background: true` parameter
+   - Command: `cd $LNBITS_PATH && uv run lnbits`
+   - This allows the user to continue working while the server runs
+
+5. Wait a few seconds for the server to start
+
+6. Verify the server is running by checking port 5000
+
+7. Inform the user the server is available at:
+   - `http://localhost:5000` (LNbits home)
+   - `http://localhost:5000/diagonalley` (Extension - requires login)
+   - `http://localhost:5000/diagonalley/market` (Public marketplace)

--- a/.claude/commands/stop.md
+++ b/.claude/commands/stop.md
@@ -1,0 +1,15 @@
+# Stop LNbits Dev Server
+
+Follow these steps:
+
+1. Check if a server is running on port 5000 using `curl -s -o /dev/null -w "%{http_code}" http://localhost:5000/`
+
+2. If no server is running, inform the user that no dev server appears to be running on port 5000
+
+3. If a server is running:
+   - Find the process ID with `lsof -ti:5000`
+   - Stop it with `kill $(lsof -ti:5000)`
+   - Verify the server has stopped by checking the port again
+   - Confirm to the user the server has been stopped
+
+4. If the normal kill doesn't work, try `kill -9 $(lsof -ti:5000)` for a force kill

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,0 +1,36 @@
+# Test Changes (Teddie's Review)
+
+This command invokes **Teddie the Tester** to test recent changes.
+
+## Steps
+
+1. **Launch Teddie** - Use the Task tool to spawn Teddie the Tester agent:
+
+   ```
+   Task tool with subagent_type: "general-purpose"
+   Prompt: "You are Teddie the Tester. Read .claude/agents/teddie.md for your role and responsibilities. Test the recent changes in this extension."
+   ```
+
+2. **Provide context to Teddie**:
+   - Run `git diff --name-only origin/master..HEAD` to list changed files
+   - Identify which areas need testing (API, UI, etc.)
+
+3. **Teddie will**:
+   - Check if dev server is running on port 5000
+   - Use Claude Code Chrome extension to visually verify UI changes
+   - Run existing tests with `make test`
+   - Create new tests if needed in `/tests/`
+   - Update `/docs/TESTING.adoc` if testing procedures changed
+
+4. **Report results**:
+   - Tests run and their results
+   - Visual verification status
+   - Any new tests created
+   - Issues found during testing
+
+## Optional Arguments
+
+- `$ARGUMENTS` can specify what to test:
+  - `/test api` - Test API endpoints only
+  - `/test ui` - Test UI components only
+  - `/test marketplace` - Test marketplace functionality

--- a/.claude/commands/vet.md
+++ b/.claude/commands/vet.md
@@ -1,0 +1,44 @@
+# Vet Extension (Archie's Review)
+
+This command invokes **Archie the Architect** to perform a comprehensive code review.
+
+## Steps
+
+1. **Launch Archie** - Use the Task tool to spawn Archie the Architect agent:
+
+   ```
+   Task tool with subagent_type: "general-purpose"
+   Prompt: "You are Archie the Architect. Read .claude/agents/archie.md for your role and responsibilities. Perform a comprehensive review of the recent changes in this extension."
+   ```
+
+2. **Provide context to Archie**:
+   - Run `git diff origin/master..HEAD` to show all changes
+   - Run `git diff --name-only origin/master..HEAD` to list changed files
+   - Include the current branch name
+
+3. **Wait for Archie's review** - Archie will:
+   - Review all changed files against his checklist
+   - Check for security concerns
+   - Verify Quasar component usage
+   - Check accessibility
+   - Review documentation in `/docs/*.adoc`
+   - Provide a structured report
+
+4. **Report results** - Present Archie's findings:
+   - Critical issues (must fix before push)
+   - Warnings (should fix)
+   - Suggestions (nice to have)
+   - Approval status
+
+5. **Handle Critical Issues**:
+   - If Critical issues found, list them clearly
+   - Do NOT proceed with push until resolved
+   - Offer to help fix the issues
+
+## Optional Arguments
+
+- `$ARGUMENTS` can specify a specific file or area to review:
+  - `/vet views.py` - Review only the views file
+  - `/vet templates/` - Review only templates
+  - `/vet security` - Focus on security concerns
+  - `/vet accessibility` - Focus on accessibility audit

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "enabledPlugins": {
+    "context7@claude-plugins-official": true,
+    "github@claude-plugins-official": true,
+    "code-review@claude-plugins-official": true,
+    "pr-review-toolkit@claude-plugins-official": true,
+    "playwright@claude-plugins-official": true
+  }
+}

--- a/.env.dev.example
+++ b/.env.dev.example
@@ -1,0 +1,10 @@
+# Development Environment Configuration
+# Copy this file to .env.dev and adjust values as needed
+
+# Path to your LNbits installation (relative to this extension directory)
+# Used by /run command to start the LNbits dev server
+LNBITS_PATH=../lnbits
+
+# Development credentials (change these!)
+username=admin
+password=changeme

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Environment files
+.env.dev
+env.dev
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+dist/
+*.egg-info/
+.eggs/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# OS
+.DS_Store
+Thumbs.db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,185 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code when working with this repository.
+
+## Repository
+
+This is a fork. The upstream (original) repository is: https://github.com/lnbits/Diagon-Alley/
+
+**Issues**: https://github.com/lnbits/Diagon-Alley/issues
+**PRs**: https://github.com/lnbits/Diagon-Alley/pulls
+
+## Project Overview
+
+Diagon Alley is an LNbits extension that provides a public Nostr marketplace aggregator. It allows users to browse and discover products from multiple Nostr merchants in one place. It implements the buyer/browser side of NIP-15 (Nostr Marketplace).
+
+## Development
+
+### Extension Development with LNbits
+
+This extension must be run inside LNbits. To set up:
+
+1. Clone LNbits to a sibling directory:
+   ```bash
+   cd ..
+   git clone https://github.com/lnbits/lnbits.git
+   ```
+
+2. Create a symbolic link from LNbits extensions to this directory:
+   ```bash
+   cd lnbits/lnbits/extensions
+   ln -s ../../../diagon-alley diagonalley
+   ```
+
+3. Configure your development environment:
+   ```bash
+   # Copy the example file
+   cp .env.dev.example .env.dev
+   # Edit .env.dev to point to your LNbits installation if needed
+   ```
+
+4. Use slash commands to manage the dev server:
+   - `/run` - Start LNbits dev server in background
+   - `/stop` - Stop the LNbits dev server
+
+### Routes
+
+| Route | Description | Auth Required |
+|-------|-------------|---------------|
+| `/diagonalley/` | Extension landing page | Yes (LNbits user) |
+| `/diagonalley/market` | Public marketplace | No |
+
+### UI Notes
+
+- When LNbits shows an "I understand" popup (e.g., for funding source warnings), click it to dismiss and continue.
+
+## Before Committing
+
+1. Run formatters:
+   ```bash
+   make format
+   ```
+
+2. Run checks:
+   ```bash
+   make check
+   ```
+
+3. Commit and push changes
+
+## Nostr Protocol References
+
+- **NIP-15** (Marketplace): https://github.com/nostr-protocol/nips/blob/master/15.md
+- **NIP-99** (Classified Listings): https://github.com/nostr-protocol/nips/blob/master/99.md
+- **NIP-07** (Browser Extension): https://github.com/nostr-protocol/nips/blob/master/07.md
+- **NIP-65** (Relay List Metadata): https://github.com/nostr-protocol/nips/blob/master/65.md
+- **Gamma Markets Spec**: https://github.com/GammaMarkets/market-spec
+
+---
+
+## Claude Code Best Practices
+
+### Before Making Changes
+
+1. **Read before editing** - Always read the file before making changes
+2. **Understand the pattern** - Check similar existing code for conventions
+3. **Run checks** - Use `make check` before committing
+
+### Frontend Development (Vue.js/Quasar)
+
+The marketplace uses a pre-built Vue app from nostrmarket in `static/market/`. The extension pages use Jinja2 templates.
+
+#### Template Structure
+
+- Templates are in `templates/diagonalley/`
+- Static assets in `static/` and `static/market/`
+
+#### Quasar Components
+
+- Use Quasar components: https://quasar.dev/components
+- Common patterns:
+  - `q-dialog` with `v-model` for dialogs
+  - `q-input` with `:model-value` for readonly, `v-model` for editable
+  - `q-btn` with `@click` for actions
+
+#### LNbits API Calls
+
+```javascript
+// GET request
+const {data} = await LNbits.api.request(
+  'GET',
+  '/diagonalley/api/v1/endpoint',
+  this.inkey  // or this.adminkey for write operations
+)
+
+// Error handling
+try {
+  await LNbits.api.request(...)
+} catch (error) {
+  LNbits.utils.notifyApiError(error)
+}
+```
+
+### Backend Development (Python/FastAPI)
+
+#### API Endpoints
+
+```python
+@diagonalley_ext.get("/api/v1/resource")
+async def api_get_resource(
+    wallet: WalletTypeInfo = Depends(require_invoice_key),
+):
+    try:
+        # Business logic
+        return {"status": "ok"}
+    except Exception as ex:
+        logger.warning(ex)
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail="Error message",
+        ) from ex
+```
+
+### Git Workflow
+
+1. **Branch naming**: `feature/<description>` or `fix/<description>`
+2. **Commit messages**: Use conventional commits (`feat:`, `fix:`, `chore:`, `docs:`, etc.)
+3. **Before pushing**: Always run `make check`
+4. **PR comments**: Add context about changes and any WIP items
+
+### Slash Commands
+
+Available Claude Code commands in `.claude/commands/`:
+
+| Command | Description |
+|---------|-------------|
+| `/commit` | Run checks and commit |
+| `/push` | Vet with Archie and push |
+| `/pr` | Create a pull request |
+| `/format` | Format code |
+| `/run` | Start LNbits dev server |
+| `/stop` | Stop LNbits dev server |
+| `/vet` | Code review with Archie |
+| `/test` | Test with Teddie |
+| `/create-issue` | Create GitHub issue |
+| `/add-troubleshooting` | Add troubleshooting entry |
+
+### Agents
+
+- **Teddie the Tester** (`/test`) - Tests changes using Playwright MCP and Chrome extension
+- **Archie the Architect** (`/vet`) - Reviews code for quality, security, and accessibility
+
+### Documentation
+
+- `docs/TROUBLESHOOTING.adoc` - Common issues
+- `docs/FAQS.adoc` - Frequently asked questions
+- `docs/TESTING.adoc` - Testing guide
+- `docs/DEPLOYMENT.adoc` - Deployment guide
+- `docs/SOLUTION_DESIGN.adoc` - Architecture overview
+
+### Common Gotchas
+
+1. **Vue delimiters** - Use `${...}` not `{{...}}` (conflicts with Jinja2)
+2. **Icon names** - Use Material Icons: https://fonts.google.com/icons
+3. **Async/await** - Remember to `await` API calls
+4. **Formatting** - Run `make format` before committing

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+# Makefile for Diagon Alley LNbits extension
+
+.PHONY: format check black ruff test
+
+# Format all code
+format: black ruff
+
+# Run all checks
+check: black-check ruff-check
+
+# Format Python with black
+black:
+	uvx black .
+
+# Check Python formatting with black
+black-check:
+	uvx black --check .
+
+# Format/fix Python with ruff
+ruff:
+	uvx ruff check --fix .
+
+# Check Python with ruff
+ruff-check:
+	uvx ruff check .
+
+# Run tests
+test:
+	pytest tests/ -v

--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -1,0 +1,86 @@
+= Deployment Guide
+:toc:
+:toc-placement!:
+
+This document describes how to deploy the Diagon Alley extension.
+
+toc::[]
+
+== Prerequisites
+
+- LNbits instance (v1.4.0 or later, as defined in `config.json`)
+- Python 3.10+
+
+== Installation
+
+=== From LNbits Extension Manager
+
+1. Open your LNbits admin interface
+2. Navigate to Extensions
+3. Search for "Diagon Alley"
+4. Click Install
+
+=== Manual Installation
+
+1. Clone the repository into your LNbits extensions directory:
++
+[source,bash]
+----
+cd /path/to/lnbits/lnbits/extensions
+git clone https://github.com/lnbits/Diagon-Alley.git diagonalley
+----
+
+2. Restart LNbits to load the extension
+
+=== Development Installation (Symbolic Link)
+
+For development, create a symbolic link:
+
+[source,bash]
+----
+cd /path/to/lnbits/lnbits/extensions
+ln -s /path/to/diagon-alley diagonalley
+----
+
+== Configuration
+
+=== Routes
+
+[cols="1,2,1", options="header"]
+|===
+| Route | Description | Auth Required
+
+| `/diagonalley/` | Extension landing page | Yes (LNbits user)
+| `/diagonalley/market` | Public marketplace | No
+|===
+
+=== Sharing the Marketplace
+
+The public marketplace URL can be shared with anyone - no login required:
+
+----
+https://your-lnbits-instance.com/diagonalley/market
+----
+
+== Production Considerations
+
+=== Relay Selection
+
+Configure reliable Nostr relays for production:
+
+- Consider running your own relay for reliability
+- Use multiple relays for redundancy
+- Test relay connectivity before going live
+
+=== Security
+
+- Never expose private keys (nsec) publicly
+- Use HTTPS in production
+- Keep LNbits and extensions updated
+- Consider running behind a reverse proxy (nginx, caddy)
+
+=== Performance
+
+- The marketplace aggregates data from multiple merchants
+- Consider caching strategies for high-traffic deployments
+- Monitor relay response times

--- a/docs/FAQS.adoc
+++ b/docs/FAQS.adoc
@@ -1,0 +1,52 @@
+= Frequently Asked Questions
+:toc:
+:toc-placement!:
+
+Common questions about the Diagon Alley extension.
+
+toc::[]
+
+[cols="1,2", options="header"]
+|===
+| Question | Answer
+
+| What is Diagon Alley?
+| A public Nostr marketplace aggregator that allows users to browse and discover products from multiple Nostr merchants in one place. It implements the buyer/browser side of NIP-15.
+
+| What are the prerequisites?
+| LNbits instance (v1.4.0+, as defined in `config.json`) and Python 3.10+.
+
+| How is this different from Nostr Market?
+| Nostr Market is for merchants to create and manage their stalls. Diagon Alley is for buyers to discover and browse products across multiple merchants.
+
+| Do users need to log in?
+| No! The public marketplace at `/diagonalley/market` is accessible without login. Users only need to log in to purchase products.
+
+| What NIPs does this implement?
+| NIP-15 (Marketplace) for product browsing, NIP-07 (Browser Extension) for login support is planned.
+
+| How do I add merchants?
+| Users can add merchants by their public key (npub) or naddr identifier in the marketplace interface.
+
+| What is NIP-15?
+| NIP-15 defines the Nostr Marketplace protocol, including event kinds 30017 (stall) and 30018 (product).
+
+| What is NIP-99?
+| NIP-99 defines Classified Listings (kind 30402). Support is planned for a future release, including Gamma Markets spec compatibility.
+
+| How do payments work?
+| When a customer places an order, a Lightning invoice is generated via LNbits. Once paid, the order is confirmed.
+
+| Can I customize the marketplace appearance?
+| Admin customization features (themes, titles, branding) are planned for future releases.
+
+| Where can I see the source code?
+| The upstream repository is at https://github.com/lnbits/Diagon-Alley
+
+| Where do I report bugs or request features?
+| Open an issue at https://github.com/lnbits/Diagon-Alley/issues
+
+| How do I contribute to the project?
+| Fork the repo, create a branch, make changes, run `make check`, and submit a PR.
+
+|===

--- a/docs/SOLUTION_DESIGN.adoc
+++ b/docs/SOLUTION_DESIGN.adoc
@@ -1,0 +1,83 @@
+= Solution Design
+:toc:
+:toc-placement!:
+
+High-level architecture and design of the Diagon Alley extension.
+
+toc::[]
+
+== Overview
+
+Diagon Alley is a public marketplace aggregator that implements the buyer side of NIP-15 (Nostr Marketplace). It allows users to discover and browse products from multiple Nostr merchants.
+
+[source]
+----
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│   LNbits UI     │────▶│  Diagon Alley   │────▶│  Nostr Relays   │
+│  (Vue/Quasar)   │     │   Extension     │     │                 │
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+        │                       │
+        ▼                       ▼
+┌─────────────────┐     ┌─────────────────┐
+│  Public Market  │     │   Merchant      │
+│     (No Auth)   │     │   Stalls/Prods  │
+└─────────────────┘     └─────────────────┘
+----
+
+== Components
+
+=== Frontend (Vue.js/Quasar)
+
+* **Extension Page** (`/diagonalley/`) - LNbits user landing page
+* **Public Marketplace** (`/diagonalley/market`) - Customer-facing marketplace view
+* **Static Assets** - Pre-built Vue marketplace app in `static/market/`
+
+=== Backend (Python/FastAPI)
+
+* **Views** (`views.py`) - HTML page routes
+* **Templates** - Jinja2 templates in `templates/diagonalley/`
+
+=== Nostr Integration
+
+* **Event Types Consumed**:
+  ** Kind 30017 - Stall information (NIP-15)
+  ** Kind 30018 - Product listings (NIP-15)
+  ** Kind 0 - Merchant profiles (NIP-01)
+
+* **Relay Communication** - JavaScript client connects directly to Nostr relays
+
+== Data Flow
+
+=== Browsing Products
+
+[source]
+----
+1. User visits /diagonalley/market
+2. JavaScript loads merchant list (from localStorage or defaults)
+3. Connects to configured Nostr relays
+4. Subscribes to kind 30017/30018 events for each merchant
+5. Renders stalls and products in the UI
+----
+
+=== Adding a Merchant
+
+[source]
+----
+1. User enters npub or naddr
+2. JavaScript decodes the identifier
+3. Subscribes to merchant's events on relays
+4. Stores merchant in localStorage
+5. Products appear in the marketplace
+----
+
+== Key Design Decisions
+
+1. **Client-side Nostr** - Relay connections handled in browser JavaScript
+2. **No server-side storage** - Merchant preferences stored in localStorage
+3. **Public access** - Marketplace viewable without LNbits authentication
+4. **Pre-built Vue app** - Uses bundled marketplace from nostrmarket project
+
+== Related Projects
+
+* https://github.com/lnbits/nostrmarket[Nostr Market] - Merchant stall management (seller side)
+* https://github.com/lnbits/lnbits[LNbits] - Lightning Network wallet/accounts system

--- a/docs/TESTING.adoc
+++ b/docs/TESTING.adoc
@@ -1,0 +1,103 @@
+= Testing Guide
+:toc:
+:toc-placement!:
+
+This document describes how to test the Diagon Alley extension.
+
+toc::[]
+
+== Running Tests
+
+=== Unit Tests
+
+Run the test suite with pytest:
+
+[source,bash]
+----
+make test
+----
+
+This runs pytest on the `tests/` directory.
+
+=== Manual Testing
+
+==== Prerequisites
+
+1. LNbits must be running (use `/run` command or start manually)
+2. Extension must be enabled in LNbits
+
+==== Testing the Public Marketplace
+
+1. Open http://localhost:5000/diagonalley/market in your browser
+2. Test the following functionality:
+   - Default merchants load (if configured)
+   - Adding a merchant by npub
+   - Browsing products
+   - Searching/filtering products
+   - Product detail view
+
+==== Testing with Claude Code
+
+Use the Claude Code Chrome extension to:
+
+1. Open the application in a Chromium-based browser (Edge, Chrome, or Brave)
+2. Take screenshots to verify UI changes
+3. Interact with the application to test functionality
+
+== Code Quality Checks
+
+Before committing, run all checks:
+
+[source,bash]
+----
+make check
+----
+
+This runs:
+
+- `black --check` - Python code formatting check
+- `ruff check` - Python linting
+
+== Formatting Code
+
+To automatically format code:
+
+[source,bash]
+----
+make format
+----
+
+This runs:
+
+- `black` - Formats Python files
+- `ruff --fix` - Fixes Python linting issues
+
+== Test Structure
+
+Organize tests in `/tests/` following LNbits conventions:
+
+[source]
+----
+tests/
+├── __init__.py
+├── conftest.py      # Shared fixtures
+├── api/             # API endpoint tests
+│   └── test_*.py
+├── unit/            # Unit tests
+│   └── test_*.py
+└── ui/              # Playwright UI tests
+    └── test_*.py
+----
+
+== Writing Tests
+
+[source,python]
+----
+import pytest
+
+@pytest.mark.asyncio
+async def test_marketplace_route():
+    """Test that marketplace route returns 200."""
+    # Test implementation
+    pass
+----

--- a/docs/TROUBLESHOOTING.adoc
+++ b/docs/TROUBLESHOOTING.adoc
@@ -1,0 +1,48 @@
+= Troubleshooting Guide
+:toc:
+:toc-placement!:
+
+This document contains common problems and their solutions when working with the Diagon Alley extension.
+
+toc::[]
+
+== Common Issues
+
+[cols="1,2", options="header"]
+|===
+| Problem | Solution
+
+| Extension not appearing in LNbits
+| Ensure the extension is symlinked correctly to `lnbits/lnbits/extensions/diagonalley`. Restart LNbits.
+
+| `make format` fails with "command not found"
+| Install Python dependencies with `pip install black ruff` or `uv pip install black ruff`.
+
+| `make check` fails with formatting errors
+| Run `make format` first to auto-fix formatting issues, then re-run `make check`.
+
+| Marketplace shows no products
+| Check that you have merchants added. Add merchants by their npub or naddr in the marketplace interface.
+
+| Relay connection fails
+| Verify the relay URLs are correct and accessible. Try different relays from the defaults list.
+
+| Products not loading from a merchant
+| The merchant may not have published products to the relays you're connected to. Try adding more relays.
+
+| Images not loading
+| Verify image URLs are accessible (HTTPS recommended). Check that image hosting allows cross-origin requests.
+
+| LocalStorage not persisting
+| Check browser privacy settings. Some browsers clear localStorage in private/incognito mode.
+
+| LNbits dev server won't start
+| Check if port 5000 is already in use with `lsof -ti:5000`. Kill existing processes or use a different port.
+
+| Vue template variables not rendering
+| Use `${...}` delimiters, not `{{...}}` (conflicts with Jinja2).
+
+| Material icon not showing
+| Check icon name at https://fonts.google.com/icons (e.g., use `storefront` not `store`).
+
+|===


### PR DESCRIPTION
## Summary

Adds Claude Code development configuration including slash commands, agents, and documentation.

cc @arcbtc

### Installing Claude Code (Linux)

```bash
npm install -g @anthropic-ai/claude-code
claude
```

Then authenticate with your Anthropic API key.

### Agents

- **Teddie the Tester** (`/test`) - Tests changes using Playwright MCP and Chrome extension
- **Archie the Architect** (`/vet`) - Reviews code for quality, security, and accessibility

### Slash Commands

| Command | Description |
|---------|-------------|
| `/commit` | Run checks and commit |
| `/push` | Vet with Archie and push |
| `/pr` | Create a pull request |
| `/format` | Format code |
| `/run` | Start LNbits dev server |
| `/stop` | Stop LNbits dev server |
| `/vet` | Code review with Archie |
| `/test` | Test with Teddie |
| `/create-issue` | Create GitHub issue |
| `/add-troubleshooting` | Add troubleshooting entry |

### Documentation Added

- `docs/TROUBLESHOOTING.adoc` - Common issues
- `docs/FAQS.adoc` - Frequently asked questions
- `docs/TESTING.adoc` - Testing guide
- `docs/DEPLOYMENT.adoc` - Deployment guide
- `docs/SOLUTION_DESIGN.adoc` - Architecture overview

### Other Changes

- Added `Makefile` with `format` and `check` targets
- Added `.env.dev.example` for development configuration
- Updated `CLAUDE.md` with comprehensive development guide
- Updated `.gitignore`

Definitely not created with Claude Code